### PR TITLE
Set training epochs in train_combogan.sh

### DIFF
--- a/scripts/train_combogan.sh
+++ b/scripts/train_combogan.sh
@@ -2,5 +2,5 @@ python train.py  \
     --dataroot ./datasets/robotcar  \
     --name robotcar_night2day  \
     --n_domains 2  \
-    --niter 25  --niter_decay 25  \
+    --niter 75  --niter_decay 75  \
     --loadSize 512  --fineSize 384


### PR DESCRIPTION
For better reproducibility, sets the defaults to the correct number of training epochs.
See https://github.com/AAnoosheh/ToDayGAN/issues/20